### PR TITLE
Improve Windows compatibility

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -456,8 +456,12 @@ class Dcm2niix(CommandLine):
         filenames = []
         for line in stdout.split("\n"):
             if line.startswith("Convert "):  # output
-                fname = str(re.search(r"\S+/\S+", line).group(0))
-                filenames.append(os.path.abspath(fname))
+                # Accept both forward and backslashes so Windows paths are
+                # correctly captured when parsing the converter output.
+                match = re.search(r"\S+[\\/]\S+", line)
+                if match:
+                    fname = str(match.group(0))
+                    filenames.append(os.path.abspath(fname))
         return filenames
 
     def _parse_files(self, filenames):

--- a/nipype/interfaces/tests/test_dcm2nii.py
+++ b/nipype/interfaces/tests/test_dcm2nii.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 
@@ -30,3 +31,11 @@ def test_search_files(tmp_path, fname, extension, search_crop):
             assert f in (str(test_cropped_file), str(test_file))
         else:
             assert str(test_file) == f
+
+
+def test_parse_stdout_windows_path():
+    """Ensure _parse_stdout handles backslash-separated paths."""
+    dcm = dcm2nii.Dcm2niix()
+    line = "Convert 1 C:\\data\\file.nii"
+    paths = dcm._parse_stdout(line)
+    assert paths == [os.path.abspath("C:\\data\\file.nii")]

--- a/nipype/utils/subprocess.py
+++ b/nipype/utils/subprocess.py
@@ -8,6 +8,9 @@ import errno
 import select
 import locale
 import datetime
+import queue
+import threading
+import time
 from pathlib import Path
 from subprocess import Popen, STDOUT, PIPE
 from .filemanip import canonicalize_env, read_stream
@@ -121,34 +124,74 @@ def run_command(runtime, output=None, timeout=0.01, write_cmdline=False):
     if output == "stream":
         streams = [Stream("stdout", proc.stdout), Stream("stderr", proc.stderr)]
 
-        def _process(drain=0):
-            try:
-                res = select.select(streams, [], [], timeout)
-            except OSError as e:
-                iflogger.info(e)
-                if e.errno == errno.EINTR:
-                    return
+        if os.name == "nt":
+            # select.select() does not work with regular pipes on Windows.
+            # Use a small reader thread per stream to push data into a queue
+            # so we can poll for updates similar to the POSIX implementation.
+            q = queue.Queue()
+
+            def _reader(stream):
+                for line in iter(stream._impl.readline, b""):
+                    q.put((stream._name, line.decode(stream.default_encoding)))
+                q.put(None)
+
+            threads = [threading.Thread(target=_reader, args=(s,)) for s in streams]
+            for t in threads:
+                t.daemon = True
+                t.start()
+
+            active = len(threads)
+            while active:
+                try:
+                    item = q.get(timeout=timeout)
+                except queue.Empty:
+                    if proc.poll() is not None and all(
+                        not t.is_alive() for t in threads
+                    ):
+                        break
+                    continue
+                if item is None:
+                    active -= 1
+                    continue
+                name, text = item
+                now = datetime.datetime.now().isoformat()
+                result[name].append(text.rstrip())
+                msg = f"{name} {now}:{text.rstrip()}"
+                result["merged"].append(msg)
+                iflogger.info(msg)
+
+            for t in threads:
+                t.join()
+        else:
+            # POSIX path: use select() to wait for activity on stdout/stderr
+            # and read incrementally so output can be logged in real time.
+            def _process(drain=0):
+                try:
+                    res = select.select(streams, [], [], timeout)
+                except OSError as e:
+                    iflogger.info(e)
+                    if e.errno == errno.EINTR:
+                        return
+                    else:
+                        raise
                 else:
-                    raise
-            else:
-                for stream in res[0]:
-                    stream.read(drain)
+                    for stream in res[0]:
+                        stream.read(drain)
 
-        while proc.returncode is None:
-            proc.poll()
-            _process()
+            while proc.returncode is None:
+                proc.poll()
+                _process()
 
-        _process(drain=1)
+            _process(drain=1)
 
-        # collect results, merge and return
-        result = {}
-        temp = []
-        for stream in streams:
-            rows = stream._rows
-            temp += rows
-            result[stream._name] = [r[2] for r in rows]
-        temp.sort()
-        result["merged"] = [r[1] for r in temp]
+            # collect results, merge and return
+            temp = []
+            for stream in streams:
+                rows = stream._rows
+                temp += rows
+                result[stream._name] = [r[2] for r in rows]
+            temp.sort()
+            result["merged"] = [r[1] for r in temp]
 
     if output.startswith("file"):
         proc.wait()


### PR DESCRIPTION
## Summary
- add thread-based fallback for running commands on Windows
- handle Windows paths in dcm2niix output parser
- test parsing of Windows style paths
- clarify new behavior with inline comments

## Testing
- `tox -qq -e style`
- `pytest nipype/interfaces/tests/test_dcm2nii.py::test_parse_stdout_windows_path -q`

------
https://chatgpt.com/codex/tasks/task_e_684a94f0087483268c796e9fb77fc4cc