### PR TITLE
Clarify Windows patch with detailed comments

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -453,9 +453,18 @@ class Dcm2niix(CommandLine):
         return runtime
 
     def _parse_stdout(self, stdout):
+        """Extract generated file paths from ``dcm2niix`` output.
+
+        ``dcm2niix`` reports each produced file using the ``Convert`` prefix
+        followed by a path.  Historically this path used forward slashes, but
+        on Windows backslashes may be emitted instead.  The regular expression
+        below therefore accepts either separator so that both ``C:\path`` and
+        ``/path`` style strings are recognized.
+        """
+
         filenames = []
         for line in stdout.split("\n"):
-            if line.startswith("Convert "):  # output
+            if line.startswith("Convert "):  # output line with a path
                 # Accept both forward and backslashes so Windows paths are
                 # correctly captured when parsing the converter output.
                 match = re.search(r"\S+[\\/]\S+", line)

--- a/nipype/interfaces/tests/test_dcm2nii.py
+++ b/nipype/interfaces/tests/test_dcm2nii.py
@@ -34,7 +34,11 @@ def test_search_files(tmp_path, fname, extension, search_crop):
 
 
 def test_parse_stdout_windows_path():
-    """Ensure _parse_stdout handles backslash-separated paths."""
+    """Ensure ``_parse_stdout`` correctly parses Windows-style paths."""
+
+    # ``dcm2niix`` may emit paths using backslashes when running on Windows.
+    # This test mimics such output to verify the regex accepts the backslash
+    # separator and the resulting path is normalized correctly.
     dcm = dcm2nii.Dcm2niix()
     line = "Convert 1 C:\\data\\file.nii"
     paths = dcm._parse_stdout(line)

--- a/nipype/utils/subprocess.py
+++ b/nipype/utils/subprocess.py
@@ -125,14 +125,18 @@ def run_command(runtime, output=None, timeout=0.01, write_cmdline=False):
         streams = [Stream("stdout", proc.stdout), Stream("stderr", proc.stderr)]
 
         if os.name == "nt":
-            # select.select() does not work with regular pipes on Windows.
-            # Use a small reader thread per stream to push data into a queue
-            # so we can poll for updates similar to the POSIX implementation.
+            # ``select.select()`` is limited to sockets on Windows and
+            # therefore cannot be used with the regular pipes returned by
+            # ``Popen``.  To emulate non-blocking reads we spin up a small
+            # thread per stream.  Each thread pushes incoming lines onto a
+            # ``Queue`` which is then polled in the loop below.
             q = queue.Queue()
 
             def _reader(stream):
                 for line in iter(stream._impl.readline, b""):
                     q.put((stream._name, line.decode(stream.default_encoding)))
+                # ``None`` indicates the thread finished reading this stream
+                # and allows the main loop to know when all threads are done.
                 q.put(None)
 
             threads = [threading.Thread(target=_reader, args=(s,)) for s in streams]
@@ -141,6 +145,9 @@ def run_command(runtime, output=None, timeout=0.01, write_cmdline=False):
                 t.start()
 
             active = len(threads)
+            # Poll the queue until each reader thread has finished.  The
+            # ``timeout`` parameter matches the behaviour of ``select`` on
+            # POSIX systems by preventing indefinite blocking.
             while active:
                 try:
                     item = q.get(timeout=timeout)


### PR DESCRIPTION
## Summary
- expand `_parse_stdout` description for Windows-style paths
- explain test for Windows path parsing
- document streaming implementation for Windows pipes

## Testing
- `pytest nipype/interfaces/tests/test_dcm2nii.py::test_parse_stdout_windows_path -q`

------
https://chatgpt.com/codex/tasks/task_e_684aaa2d06e483269a88e2045f060757