### PR TITLE
Fix Windows duplicate detection in dcm2niix output

### DIFF
--- a/nipype/interfaces/dcm2nii.py
+++ b/nipype/interfaces/dcm2nii.py
@@ -464,13 +464,13 @@ class Dcm2niix(CommandLine):
 
         filenames = []
         for line in stdout.split("\n"):
-            if line.startswith("Convert "):  # output line with a path
+            if line.startswith("Convert "):
                 # Accept both forward and backslashes so Windows paths are
                 # correctly captured when parsing the converter output.
                 match = re.search(r"\S+[\\/]\S+", line)
                 if match:
-                    fname = str(match.group(0))
-                    filenames.append(os.path.abspath(fname))
+                    fname = os.path.abspath(str(match.group(0)))
+                    filenames.append(os.path.normpath(fname))
         return filenames
 
     def _parse_files(self, filenames):
@@ -495,9 +495,14 @@ class Dcm2niix(CommandLine):
                 elif fl.endswith((".json", ".txt")):
                     bids.append(fl)
 
-        # in siemens mosaic conversion nipype misread dcm2niix output and generate a duplicate list of results
-        # next line remove duplicates from output files array
-        outfiles = list(dict.fromkeys(outfiles))
+        # remove duplicates
+        if os.name == "nt":
+            uniq = {}
+            for f in outfiles:
+                uniq[f.lower()] = f
+            outfiles = list(uniq.values())
+        else:
+            outfiles = list(dict.fromkeys(outfiles))
 
         self.output_files = outfiles
         self.bvecs = bvecs

--- a/nipype/interfaces/tests/test_dcm2nii.py
+++ b/nipype/interfaces/tests/test_dcm2nii.py
@@ -43,3 +43,21 @@ def test_parse_stdout_windows_path():
     line = "Convert 1 C:\\data\\file.nii"
     paths = dcm._parse_stdout(line)
     assert paths == [os.path.abspath("C:\\data\\file.nii")]
+
+
+def test_parse_files_case_insensitive(monkeypatch):
+    """Deduplicate files ignoring case on Windows."""
+
+    dcm = dcm2nii.Dcm2niix()
+    monkeypatch.setattr(dcm2nii.os, "name", "nt", raising=False)
+
+    files = ["C:\\Data\\FILE.nii", "c:\\data\\file.nii"]
+
+    def _fake_search_files(prefix, outtypes, crop):
+        return files
+
+    monkeypatch.setattr(dcm2nii, "search_files", _fake_search_files)
+
+    dcm._parse_files(files)
+
+    assert len(dcm.output_files) == 1


### PR DESCRIPTION
## Summary
- normalise paths when parsing dcm2niix output
- deduplicate output files case-insensitively on Windows
- test deduplication on Windows paths

## Testing
- `pytest nipype/interfaces/tests/test_dcm2nii.py::test_parse_files_case_insensitive -q`
- `pytest nipype/interfaces/tests/test_dcm2nii.py::test_parse_stdout_windows_path -q`


------
https://chatgpt.com/codex/tasks/task_e_684c17e772888326ad29e5bdbcdcd445